### PR TITLE
Filter testpmd sibling threads for OCP environment

### DIFF
--- a/testpmd/cmd/main.go
+++ b/testpmd/cmd/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.Parse()
 	// if pci not specified on CLI, try enviroment vars
 	if len(pci) == 0 {
-		r, _ := regexp.Compile("PCIDEVICE")
+		r := regexp.MustCompile(`PCIDEVICE_OPENSHIFT_IO_INTELNICS\d+$`)
 		for _, e := range os.Environ() {
 			pair := strings.SplitN(e, "=", 2)
 			if r.Match([]byte(pair[0])) {
@@ -55,7 +55,7 @@ func main() {
 		log.Fatalf("pci address not provided\n")
 	}
 
-	cset := getProcCpuset()
+	cset := removeSiblings(getProcCpuset())
 	mgmt_cpu := firstCpuFromCpuset(cset)
 	var newMask unix.CPUSet
 	newMask.Set(mgmt_cpu)


### PR DESCRIPTION
In openshift enviroment, when a pod is created, the cpu manager may allocate hyper threads from the same core. In order to maximize the testpmd throughput, one hyper thread per core should be used. For example, if 6 cpus are requested, OCP may allocate 3 pairs of siblings (4,36),(5,37),(6,38). This code change will filter out 36,37,38 and only use 4,5,6.    