### PR TITLE
Trafficgen: use py-cputools module to remove sibling threads 

### DIFF
--- a/rfc2544/Dockerfile
+++ b/rfc2544/Dockerfile
@@ -14,6 +14,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip \
        && python3 -m pip install --no-cache-dir marshmallow \
        && python3 -m pip install --no-cache-dir waitress \
        && python3 -m pip install --no-cache-dir requests \
+       && python3 -m pip install --no-cache-dir py-cputools \
        && mkdir -p /opt/trex \
        && mkdir -p /var/log/tgen \
        && mkdir -p /root/tgen \

--- a/rfc2544/README.md
+++ b/rfc2544/README.md
@@ -17,10 +17,6 @@ To achieve higher traffic rate, the two trafficgen ports should come from differ
 
 In general using pysical function (PF) as the trafficgen ports can have better throughput performance than using the virtual function (VF). Building the container image based on TRex version 2.88 is recommended; the only exception is to use VF on Intel E810 nic as the trafficgen ports - in this case, building the container image based on TRex version 3.02 is recommended.
 
-## Openshift integration demo
-
-[![Watch the video](https://img.youtube.com/vi/C5s9DZC3D6c/maxresdefault.jpg)](https://youtu.be/C5s9DZC3D6c)
-
 ## Build the container image
 
 To build with the default TREX_VERSION,
@@ -30,7 +26,7 @@ podman build -t localhost/trafficgen .
 
 To build with a different TREX_VERSION, say for the purpose of running it on the virtual function on E810,
 ```
-podman build -t localhost/trafficgen --build-arg TREX_VERSION=3.02 .
+podman build -t localhost/trafficgen --build-arg TREX_VERSION=v3.02 .
 ```
 
 ## Bind trafficgen port to vfio-pci

--- a/rfc2544/README.md
+++ b/rfc2544/README.md
@@ -61,7 +61,7 @@ Also note the isolated cpu list,
 
 If the isolated cpu list from the above command is empty, then [follow the prerequisites section](#Prerequisites) to fix it.
 
-Select 7 cores from the isolated cpu list and make sure the selected cores are from numa node 1. For example, here "5,7,9,11,13,15,17" could be used.
+Select 7 cores from the isolated cpu list and ensure that the selected cores are from numa node 1. For instance, the following cores "5,7,9,11,13,15,17" could be utilized. If hypertheading is enabled, the chosen CPUs must originate from distinct cores - meaning no silbing threads should be employed. The trafficgen script will detect whether silbing threads are included in a given cpu list and will utilize only one cpu from each core. To mitigate the problem of a "noisy neighbor", the user should ensure that the silbing threads of the selected CPUs cannot be utilized to run other applications as well.
 
 For manual test, users normally do not use pod, but run the trafficgen container directly,
 ```

--- a/rfc2544/trafficgen_entry.sh
+++ b/rfc2544/trafficgen_entry.sh
@@ -23,24 +23,6 @@ function print_help() {
     echo "debug - only start the trex server in foreground"
 }
 
-function convert_number_range() {
-    # converts a range of cpus, like "1-3,5" to a list, like "1,2,3,5"
-    local cpu_range=$1
-    local cpus_list=""
-    local cpus=""
-    for cpus in `echo "${cpu_range}" | sed -e 's/,/ /g'`; do
-        if echo "${cpus}" | grep -q -- "-"; then
-            cpus=`echo ${cpus} | sed -e 's/-/ /'`
-            cpus=`seq ${cpus} | sed -e 's/ /,/g'`
-        fi
-        for cpu in ${cpus}; do
-            cpus_list="${cpus_list},${cpu}"
-        done
-    done
-    cpus_list=`echo ${cpus_list} | sed -e 's/^,//'`
-    echo "${cpus_list}"
-}
-
 function sigfunc() {
     pid=`pgrep waitress-serve`
     [ -z ${pid} ] || kill ${pid}
@@ -114,8 +96,7 @@ cd /root/tgen
 #read -a pciArray <<< $(echo ${pci_list} | sed -e 's/,/ /g')
 export NIC1=${pciArray[0]}
 export NIC2=${pciArray[1]}
-isolated_cpus=$(cat /proc/self/status | grep Cpus_allowed_list: | cut -f 2)
-read -a cpuArray <<< $(convert_number_range ${isolated_cpus} | sed -e 's/,/ /g')
+read -a cpuArray <<< $(python -m cputools --remove-siblings)
 export master_cpu=${cpuArray[0]}
 export latency_cpu=${cpuArray[1]}
 #client_cpu is used to run binary search code


### PR DESCRIPTION
In dockerfile add pip install py-cputools
In trafficgen_entry.sh use the py-cputools module to replace the shell script
Update README
