### PR TITLE
Add testpmd container deployment manifests for openshift single node cluster

### DIFF
--- a/manifests/single-node-openshift/README.md
+++ b/manifests/single-node-openshift/README.md
@@ -1,6 +1,6 @@
 # Sample Manifests for Single Node OpenShift
 
-This directory includes a collection of manifest files designed to facilitate the deployment of the "testpmd" container within a single-node OpenShift cluster. These manifests have been thoroughly tested and optimized for compatibility with OpenShift version 4.13.6. It's important to note that some of the configuration elements utilized in these manifest files might not be applicable to earlier OpenShift versions. This distinction arises due to the progressive evolution of cri-o features and related provisioning processes in preceding versions.
+This directory includes a collection of manifest files designed to facilitate the deployment of the "testpmd" container within a single-node OpenShift cluster. These manifests have been thoroughly tested and optimized for compatibility with OpenShift version 4.13.6. It's important to note that some of the configuration elements utilized in these manifest files might not be applicable to earlier OpenShift versions. This distinction arises due to the progressive evolution of CRI-O features and related provisioning processes in preceding versions.
 
 To ensure a successful deployment, it's recommended to adhere to a specific sequence when applying the YAML files. Following a fresh installation, the order of application is as follows:
 

--- a/manifests/single-node-openshift/README.md
+++ b/manifests/single-node-openshift/README.md
@@ -1,6 +1,6 @@
 # Sample Manifests for Single Node OpenShift
 
-This directory includes a collection of manifest files designed to facilitate the deployment of the "testpmd" container within a single-node OpenShift cluster. These manifests have been thoroughly tested and optimized for compatibility with OpenShift version 4.3.16. It's important to note that some of the configuration elements utilized in these manifest files might not be applicable to earlier OpenShift versions. This distinction arises due to the progressive evolution of cri-o features and related provisioning processes in preceding versions.
+This directory includes a collection of manifest files designed to facilitate the deployment of the "testpmd" container within a single-node OpenShift cluster. These manifests have been thoroughly tested and optimized for compatibility with OpenShift version 4.13.6. It's important to note that some of the configuration elements utilized in these manifest files might not be applicable to earlier OpenShift versions. This distinction arises due to the progressive evolution of cri-o features and related provisioning processes in preceding versions.
 
 To ensure a successful deployment, it's recommended to adhere to a specific sequence when applying the YAML files. Following a fresh installation, the order of application is as follows:
 

--- a/manifests/single-node-openshift/README.md
+++ b/manifests/single-node-openshift/README.md
@@ -1,0 +1,17 @@
+# Sample Manifests for Single Node OpenShift
+
+This directory includes a collection of manifest files designed to facilitate the deployment of the "testpmd" container within a single-node OpenShift cluster. These manifests have been thoroughly tested and optimized for compatibility with OpenShift version 4.3.16. It's important to note that some of the configuration elements utilized in these manifest files might not be applicable to earlier OpenShift versions. This distinction arises due to the progressive evolution of cri-o features and related provisioning processes in preceding versions.
+
+To ensure a successful deployment, it's recommended to adhere to a specific sequence when applying the YAML files. Following a fresh installation, the order of application is as follows:
+
+1. Apply performance-profile.yaml
+2. Apply sub-sriov.yaml
+3. Apply sriov-nic-policy.yaml
+4. Apply sriov-network.yaml
+5. Apply namespace.yaml
+6. Apply pod-testpmd.yaml
+
+This sequential application of the manifest files is crucial for the proper configuration and functioning of the "testpmd" container within the OpenShift environment.
+
+Once all the provided YAML files have been successfully applied in the specified order, the "testpmd" container should be optimized and prepared to efficiently forward network traffic. This sequence of manifest application ensures that the necessary configurations, profiles, policies, and network settings are in place for the "testpmd" container to function optimally within the single-node OpenShift cluster.
+

--- a/manifests/single-node-openshift/namespace.yaml
+++ b/manifests/single-node-openshift/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+

--- a/manifests/single-node-openshift/performance-profile.yaml
+++ b/manifests/single-node-openshift/performance-profile.yaml
@@ -1,0 +1,30 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+  annotations:
+    kubeletconfig.experimental: "{\"cpuManagerPolicyOptions\": {\"full-pcpus-only\": \"true\"}}"
+spec:
+  cpu:
+    isolated: 4-31,36-63
+    reserved: 0-3,32-35
+  hugepages:
+    defaultHugepagesSize: "1G"
+    pages:
+    - size: "1G"
+      count: 16
+  additionalKernelArgs:
+  - iommu=pt
+  - intel_iommu=on
+  - "rcupdate.rcu_normal_after_boot=0"
+  - "efi=runtime"
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: "" 
+  net:
+    userLevelNetworking: true
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: false 

--- a/manifests/single-node-openshift/performance-profile.yaml
+++ b/manifests/single-node-openshift/performance-profile.yaml
@@ -2,8 +2,6 @@ apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
   name: performance
-  annotations:
-    kubeletconfig.experimental: "{\"cpuManagerPolicyOptions\": {\"full-pcpus-only\": \"true\"}}"
 spec:
   cpu:
     isolated: 4-31,36-63
@@ -16,8 +14,12 @@ spec:
   additionalKernelArgs:
   - iommu=pt
   - intel_iommu=on
-  - "rcupdate.rcu_normal_after_boot=0"
-  - "efi=runtime"
+  - nmi_watchdog=0
+  - audit=0
+  - mce=off
+  - processor.max_cstate=1
+  - idle=poll
+  - intel_idle.max_cstate=0
   machineConfigPoolSelector:
     pools.operator.machineconfiguration.openshift.io/master: "" 
   net:
@@ -25,6 +27,6 @@ spec:
   nodeSelector:
     node-role.kubernetes.io/master: ""
   numa:
-    topologyPolicy: restricted
+    topologyPolicy: "single-numa-node"
   realTimeKernel:
     enabled: false 

--- a/manifests/single-node-openshift/pod-testpmd.yaml
+++ b/manifests/single-node-openshift/pod-testpmd.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1 
+kind: Pod 
+metadata:
+  name: testpmd
+  labels:
+    app: testpmd
+  namespace: benchmark 
+  annotations:
+    k8s.v1.cni.cncf.io/networks: >
+      [
+         {
+           "name": "sriov-west",
+           "mac": "00:11:22:33:00:00",
+           "namespace": "default"
+         },
+         {
+           "name": "sriov-east",
+           "mac": "00:11:22:33:00:11",
+           "namespace": "default"
+         }
+      ]
+    cpu-load-balancing.crio.io: "disable"
+    cpu-quota.crio.io: "disable"
+    irq-load-balancing.crio.io: "disable"
+spec:
+  runtimeClassName: performance-performance
+  restartPolicy: Never
+  volumes:
+    - name: devpages
+      emptyDir:
+        medium: HugePages
+    - name: vfio
+      hostPath:
+        path: /dev/vfio
+        #type: Directory
+    - name: lib-firmware
+      hostPath:
+        path: /lib/firmware
+    - name: dpdk
+      emptyDir: {}
+  containers:
+  - name: flexran-du 
+    image: quay.io/jianzzha/testpmd:22.11.2
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: devpages 
+      mountPath: /dev/hugepages
+    - name: vfio
+      mountPath: /dev/vfio
+    - name: lib-firmware
+      mountPath: /lib/firmware
+    - name: dpdk
+      mountPath: /var/run/dpdk
+    command:
+      - "/root/runner"
+      - "--auto"
+    resources:
+      limits:
+        cpu: "6"
+        hugepages-1Gi: 2Gi
+        memory: 1Gi 
+        openshift.io/intelnics0: "1"
+        openshift.io/intelnics1: "1"
+      requests:
+        cpu: "6"
+        hugepages-1Gi: 2Gi
+        memory: 1Gi 
+        openshift.io/intelnics0: "1"
+        openshift.io/intelnics1: "1"
+    securityContext:
+        privileged: true
+  nodeSelector:
+    node-role.kubernetes.io/master: ""

--- a/manifests/single-node-openshift/service-testpmd.yaml
+++ b/manifests/single-node-openshift/service-testpmd.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: testpmd 
+  name: testpmd
+  namespace: benchmark
+spec:
+  ports:
+  - port: 9000 
+    protocol: TCP
+    targetPort: 9000
+    name: testpmd-rest-api 
+  selector:
+    app: testpmd
+  sessionAffinity: None
+  type: NodePort 
+

--- a/manifests/single-node-openshift/sriov-network.yaml
+++ b/manifests/single-node-openshift/sriov-network.yaml
@@ -1,0 +1,28 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-west
+  namespace: openshift-sriov-network-operator
+spec:
+  ipam: ""
+  capabilities: '{ "mac": true }'
+  resourceName: intelnics0
+  vlan: 100
+  spoofChk: "off"
+  trust: "on"
+  networkNamespace: default
+---
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-east
+  namespace: openshift-sriov-network-operator
+spec:
+  ipam: ""
+  capabilities: '{ "mac": true }'
+  resourceName: intelnics1
+  vlan: 101
+  spoofChk: "off"
+  trust: "on"
+  networkNamespace: default
+

--- a/manifests/single-node-openshift/sriov-nic-policy.yaml
+++ b/manifests/single-node-openshift/sriov-nic-policy.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: policy-intel-west
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: vfio-pci
+  mtu: 9000
+  nicSelector:
+    pfNames:
+    - "ens2f0"
+  nodeSelector:
+    node-role.kubernetes.io/master: "" 
+  numVfs: 2
+  priority: 5
+  resourceName: intelnics0
+---
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: policy-intel-east
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: vfio-pci
+  mtu: 9000
+  nicSelector:
+    pfNames:
+    - "ens2f1"
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  numVfs: 2
+  priority: 5
+  resourceName: intelnics1
+

--- a/manifests/single-node-openshift/sub-sriov.yaml
+++ b/manifests/single-node-openshift/sub-sriov.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sriov-network-operator
+  annotations:
+    workload.openshift.io/allowed: management
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: sriov-network-operators
+  namespace: openshift-sriov-network-operator
+spec:
+  targetNamespaces:
+  - openshift-sriov-network-operator
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator-subsription
+  namespace: openshift-sriov-network-operator
+spec:
+  channel: "stable"
+  name: sriov-network-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The added manifests were tested with OCP 4.13.6 and can achieve the same throughput as running the testpmd container in RHEL.  