### PR TITLE
Update PCIDEVICE_OPENSHIFT env var matching string

### DIFF
--- a/testpmd/cmd/main.go
+++ b/testpmd/cmd/main.go
@@ -42,10 +42,10 @@ func main() {
 	flag.Parse()
 	// if pci not specified on CLI, try enviroment vars
 	if len(pci) == 0 {
-		r := regexp.MustCompile(`PCIDEVICE_OPENSHIFT_IO_INTELNICS\d+$`)
+		r := regexp.MustCompile(`PCIDEVICE_OPENSHIFT_IO_[A-Za-z0-9_]+$`)
 		for _, e := range os.Environ() {
 			pair := strings.SplitN(e, "=", 2)
-			if r.Match([]byte(pair[0])) {
+			if r.Match([]byte(pair[0])) && strings.HasSuffix(pair[0], "_INFO") == false {
 				pci = append(pci, normalizePci(pair[1]))
 			}
 		}

--- a/testpmd/cmd/main.go
+++ b/testpmd/cmd/main.go
@@ -45,7 +45,7 @@ func main() {
 		r := regexp.MustCompile(`PCIDEVICE_OPENSHIFT_IO_[A-Za-z0-9_]+$`)
 		for _, e := range os.Environ() {
 			pair := strings.SplitN(e, "=", 2)
-			if r.Match([]byte(pair[0])) && strings.HasSuffix(pair[0], "_INFO") == false {
+			if r.Match([]byte(pair[0])) && !strings.HasSuffix(pair[0], "_INFO") {
 				pci = append(pci, normalizePci(pair[1]))
 			}
 		}


### PR DESCRIPTION
The original implementation requires the network resource name in the form of "resourceName: intelnics<digits>", otherwise matching the env var will fail. Some user didn't follow the sample manifests and observed that the testpmd fail to start.

This fix is to allow the users to choose their own resource name; openshift also add extra env var that has suffix "_INFO" but with the same prefix that we try to match, we will skip those env vars.

