### PR TITLE
Update container image url to organizational repo

### DIFF
--- a/manifests/single-node-openshift/pod-dpdk-telemetry.yaml
+++ b/manifests/single-node-openshift/pod-dpdk-telemetry.yaml
@@ -40,7 +40,7 @@ spec:
       emptyDir: {}
   containers:
   - name: flexran-du
-    image: quay.io/jianzzha/testpmd:22.11.2
+    image: quay.io/container-perf-tools/testpmd:22.11.2
     imagePullPolicy: Always
     volumeMounts:
     - name: devpages

--- a/manifests/single-node-openshift/pod-testpmd.yaml
+++ b/manifests/single-node-openshift/pod-testpmd.yaml
@@ -40,7 +40,7 @@ spec:
       emptyDir: {}
   containers:
   - name: flexran-du
-    image: quay.io/jianzzha/testpmd:22.11.2
+    image: quay.io/container-perf-tools/testpmd:22.11.2
     imagePullPolicy: Always
     volumeMounts:
     - name: devpages


### PR DESCRIPTION
All quay.io container image URLs should use the organizational URL quay.io/container-perf-tools rather than individual's personal URL