### PR TITLE
Hotfix on testpmd sibling list filter

### DIFF
--- a/testpmd/cmd/cpu.go
+++ b/testpmd/cmd/cpu.go
@@ -45,7 +45,7 @@ func removeSiblings(cset cpuset.CPUSet) cpuset.CPUSet {
 			log.Fatal(err)
 		}
 		siblings := siblingSet.List()
-		cores = append(cores, siblings[0])
+		cores = append(cores, cpu)
 		for _, sibling := range siblings {
 			visited[sibling] = 1
 		}


### PR DESCRIPTION
The original implementation of the CPU list filtering has an assumption that the user will supply all threads from the same core to run the testpmd container. This assumption is not true: say 0 and 24 are siblings, and the user may supply 23,24,25. In this case, the original implementation will use 0 to replace 24, 1 to replace 25, therefore generate 23,0,1. The fix is simple: use the requested CPU from a sibling set, rather than the "first" CPU from the sibling set. 