### PR TITLE
Hot fix: trafficgen rest api does not accept dst_macs

### DIFF
--- a/rfc2544/rest.py
+++ b/rfc2544/rest.py
@@ -103,11 +103,11 @@ class RestApi:
         if checkIfProcessRunning("binary-search"):
             if not killProcessByName("binary-search"):
                 return jsonify(False)
+
         start_schema = StartSchema()
-        result = start_schema.load(request_data)
-        if result["l3"]:
+        if request_data["l3"]:
             start_schema = StartSchemal3()
-            result = start_schema.load(request_data)
+        result = start_schema.load(request_data)
 
         binary_search_command = ["./binary-search.py", "--traffic-generator=trex-txrx"]
         for field in result:


### PR DESCRIPTION
The trafficgen rest api does not accept the following json content,

curl -X POST http://localhost:8080/trafficgen/start -H 'Content-Type: application/json' -d '{
    "l3":true,
    "device_pairs":"0:1",
    "search_runtime": 10,
    "validation_runtime":30,
    "num_flows":1000,
    "frame_size":64,
    "max_loss_pct":0.002,
    "sniff_runtime":10,
    "search_granularity":5.0,
    "teaching_warmup_packet_type":"generic",
    "teaching_warmup_packet_rate":10000,
    "use_src_ip_flows":1,
    "use_dst_ip_flows":1,
    "use_src_mac_flows":0,
    "use_dst_mac_flows":0,
    "send_teaching_warmup": true,
    "rate_tolerance": 10,
    "runtime_tolerance": 10,
    "rate": 50,
    "rate_unit": "%",
    "no_promisc": true,
    "one_shot": 1,
    "dst_macs": "00:11:22:33:00:00,00:11:22:33:00:11"
}'

This is because the class StartSchema does not have "dst_macs" and will fail first.

